### PR TITLE
Modification of replace-related methods

### DIFF
--- a/docs/basic-types.md
+++ b/docs/basic-types.md
@@ -62,7 +62,7 @@ String is one of the most widely used data types in programming languages, maste
 | Concatenate   | `myStr1 + myStr2`                  | `my_str1 + my_str2`                    |
 | Slice   | `myStr.slice(start, end)`        | `my_str[start:end]`                 |
 | Find   | `myStr.indexOf(substring)`       | `my_str.index(substring)`           |
-| Replace   | `myStr.replace(old, new)`        | `my_str.replace(old, new)`          |
+| Replace   | `myStr.replaceAll(old, new)`        | `my_str.replace(old, new)`          |
 | Split   | `myStr.split(separator)`         | `my_str.split(separator)`           |
 | Convert to uppercase and lowercase | `myStr.toUpperCase()`<br />`myStr.toLowerCase()` | `my_str.upper()`<br />`my_str.lower()` |
 | Reverse	| `myStr.split('').reverse().join('')`	| `my_str[::-1]` |

--- a/docs/re-module.md
+++ b/docs/re-module.md
@@ -62,7 +62,7 @@ In Python, prefixing a string with `r` indicates a raw string literal, which tre
 | Matching a regular expression | `myReg.test(myStr)` | `my_regex.match(my_str)` |
 | Finding the first match | `myReg.exec(myStr)` | `my_regex.search(my_str)` |
 | Finding all matches | `myStr.match(myReg)` | `my_regex.findall(my_str)` |
-| Replacing matches | `myStr.replace(myReg, replacement)` | `my_regex.sub(replacement, my_str)` |
+| Replacing matches | `myStr.replaceAll(myReg, replacement)` | `my_regex.sub(replacement, my_str)` |
 | Splitting a string using a regular expression | `myStr.split(myReg)` | `my_regex.split(my_str)` |
 
 :::tip

--- a/i18n/zh-cn/docusaurus-plugin-content-docs/current/basic-types.md
+++ b/i18n/zh-cn/docusaurus-plugin-content-docs/current/basic-types.md
@@ -62,7 +62,7 @@ print(type(name)) # 获取变量的类型
 | 拼接   | `myStr1 + myStr2`                  | `my_str1 + my_str2`                    |
 | 截取   | `myStr.slice(start, end)`        | `my_str[start:end]`                 |
 | 查找   | `myStr.indexOf(substring)`       | `my_str.index(substring)`           |
-| 替换   | `myStr.replace(old, new)`        | `my_str.replace(old, new)`          |
+| 替换   | `myStr.replaceAll(old, new)`        | `my_str.replace(old, new)`          |
 | 分割   | `myStr.split(separator)`         | `my_str.split(separator)`           |
 | 大小写转换 | `myStr.toUpperCase()`<br />`myStr.toLowerCase()` | `my_str.upper()`<br />`my_str.lower()` |
 | 反转	| `myStr.split('').reverse().join('')`	| `my_str[::-1]` |

--- a/i18n/zh-cn/docusaurus-plugin-content-docs/current/re-module.md
+++ b/i18n/zh-cn/docusaurus-plugin-content-docs/current/re-module.md
@@ -63,7 +63,7 @@ Python 中的字符串前面添加 `r`，表示不对字符串字面量进行转
 | 匹配正则表达式 | `myReg.test(myStr)` | `my_regex.match(my_str)` |
 | 查找第一个匹配项 | `myReg.exec(myStr)` | `my_regex.search(my_str)` |
 | 查找所有匹配项 | `myStr.match(myReg)` | `my_regex.findall(my_str)` |
-| 替换匹配项 | `myStr.replace(myReg, replacement)` | `my_regex.sub(replacement, my_str)` |
+| 替换匹配项 | `myStr.replaceAll(myReg, replacement)` | `my_regex.sub(replacement, my_str)` |
 | 使用正则表达式拆分字符串 | `myStr.split(myReg)` | `my_regex.split(my_str)` |
 
 :::tip


### PR DESCRIPTION
In JavaScript, `replace` defaults to replacing the first match. When comparing equivalent methods with Python, it has been replaced with `replaceAll`.